### PR TITLE
add close PsychPortAudio close to clean up

### DIFF
--- a/cleanUp.m
+++ b/cleanUp.m
@@ -12,6 +12,11 @@ ShowCursor
 % Screen Close All
 sca;
 
+% Close Psychportaudio if open 
+if PsychPortAudio('GetOpenDeviceCount') ~= 0
+	PsychPortAudio('Close');
+end
+
 if ~ismac
     % remove PsychDebugWindowConfiguration
     clear Screen


### PR DESCRIPTION
Just added a couple of line that checks if an audio device was opened and therefore needs to be close. Have you had in mind something like this in #7 ?