### PR TITLE
refactor initPTB

### DIFF
--- a/initPTB.m
+++ b/initPTB.m
@@ -45,33 +45,10 @@ InitializePsychSound(1);
 % Get the screen numbers and draw to the external screen if avaliable
 cfg.screen = max(Screen('Screens'));
 
-% init PTB with different options in concordance to the Debug Parameters
-if cfg.debug
-
-    % set to one because we don not care about time
-    Screen('Preference', 'SkipSyncTests', 2);
-    Screen('Preference', 'Verbosity', 0);
-    Screen('Preferences', 'SuppressAllWarnings', 2);
-
-    if cfg.testingSmallScreen
-        [cfg.win, cfg.winRect] = Screen('OpenWindow', cfg.screen, cfg.backgroundColor,  [0,0, 480, 270]);
-    else
-        if cfg.testingTranspScreen
-        PsychDebugWindowConfiguration
-        end
-        [cfg.win, cfg.winRect] = Screen('OpenWindow', cfg.screen, cfg.backgroundColor);
-    end
-
-else
-    Screen('Preference','SkipSyncTests', 0);
-    [cfg.win, cfg.winRect] = Screen('OpenWindow', cfg.screen, cfg.backgroundColor);
-
-end
-
+cfg = openWindow(cfg);
 
 % window size info
 [cfg.winWidth, cfg.winHeight] = WindowSize(cfg.win);
-
 
 
 
@@ -97,11 +74,7 @@ V = 2*(180*(atan(cfg.monitorWidth/(2*cfg.screenDistance))/pi));
 cfg.ppd = cfg.winRect(3)/V;
 
 
-% Enable alpha-blending, set it to a blend equation useable for linear
-% superposition with alpha-weighted source.
-Screen('BlendFunction', cfg.win, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
-
+%% Select specific text font, style and size:
 %% Text and Font
 % Select specific text font, style and size:
 Screen('TextFont',cfg.win, cfg.textFont );
@@ -134,6 +107,23 @@ cfg.vbl = Screen('Flip', cfg.win);
 
 end
 
+
+function initDebug(cfg)
+
+% init PTB with different options in concordance to the debug Parameters
+Screen('Preference','SkipSyncTests', 0);
+if cfg.debug
+    Screen('Preference', 'SkipSyncTests', 2);
+    Screen('Preference', 'Verbosity', 0);
+    Screen('Preferences', 'SuppressAllWarnings', 2);
+end
+
+if cfg.testingTranspScreen
+    PsychDebugWindowConfiguration
+end
+
+end
+
 function initKeyboard(cfg)
 % Make sure keyboard mapping is the same on all supported operating systems
 % Apple MacOS/X, MS-Windows and GNU/Linux:
@@ -153,4 +143,20 @@ testKeyboards(cfg)
 
 % Don't echo keypresses to Matlab window
 ListenChar(-1);
+end
+
+function cfg = openWindow(cfg)
+
+if cfg.testingSmallScreen
+    [cfg.win, cfg.winRect] = Screen('OpenWindow', cfg.screen, cfg.backgroundColor,  [0,0, 480, 270]);
+else
+    [cfg.win, cfg.winRect] = Screen('OpenWindow', cfg.screen, cfg.backgroundColor);
+end
+
+%TODO make this optional
+
+% Enable alpha-blending, set it to a blend equation useable for linear
+% superposition with alpha-weighted source.
+Screen('BlendFunction', cfg.win, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
 end

--- a/initPTB.m
+++ b/initPTB.m
@@ -27,26 +27,7 @@ AssertOpenGL;
 
 
 %% Keyboard
-% Make sure keyboard mapping is the same on all supported operating systems
-% Apple MacOS/X, MS-Windows and GNU/Linux:
-KbName('UnifyKeyNames');
-
-
-
-
-% ---------- FIX LATER ---------- %
-% might be over agressive to test this at every PTB init maybe make it
-% dependent on a debug "flag"
-
-testKeyboards(cfg)
-
-% ---------- FIX LATER ---------- %
-
-
-
-
-% Don't echo keypresses to Matlab window
-ListenChar(-1);
+initKeyboard(cfg)
 
 
 %% Mouse
@@ -151,4 +132,25 @@ GetSecs;
 cfg.vbl = Screen('Flip', cfg.win);
 
 
+end
+
+function initKeyboard(cfg)
+% Make sure keyboard mapping is the same on all supported operating systems
+% Apple MacOS/X, MS-Windows and GNU/Linux:
+KbName('UnifyKeyNames');
+
+
+
+% ---------- FIX LATER ---------- %
+% might be over agressive to test this at every PTB init maybe make it
+% dependent on a debug "flag"
+
+testKeyboards(cfg)
+
+% ---------- FIX LATER ---------- %
+
+
+
+% Don't echo keypresses to Matlab window
+ListenChar(-1);
 end

--- a/initPTB.m
+++ b/initPTB.m
@@ -1,19 +1,21 @@
 function [cfg] = initPTB(cfg)
 % This will initialize PsychToolBox
 % - screen
-%   - the windon opened takes the whole screen by default
-%   - set in debug mode with window transparency if necessary
-%   - can skip synch test if you ask for it (nicely)
+%   - the windon opened takes the whole screen unless
+%       cfg.testingSmallScreen is set to true 
+%   - debug mode : skips synch test and warnings
+%   - window transparency enabled by cfg.testingTranspScreen set to true
 %   - gets the flip interval
-%   - computes the pixel per degree of visual angle
+%   - computes the pixel per degree of visual angle:
+%       the computation for ppd assumes the windows takes the whole screenDistance
 %   - set font details
 % - keyboard
+% - hides cursor
 % - sound
 
 
 % TO DO
 % - We might want to add a couple of IF in case the experiment does not use audio for example.
-% - the computation for ppd assumes the windows takes the whole screenDistance
 
 
 checkDependencies()
@@ -120,6 +122,7 @@ end
 end
 
 function initKeyboard(cfg)
+
 % Make sure keyboard mapping is the same on all supported operating systems
 % Apple MacOS/X, MS-Windows and GNU/Linux:
 KbName('UnifyKeyNames');
@@ -138,6 +141,7 @@ testKeyboards(cfg)
 
 % Don't echo keypresses to Matlab window
 ListenChar(-1);
+
 end
 
 function cfg = openWindow(cfg)
@@ -157,6 +161,8 @@ Screen('BlendFunction', cfg.win, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 end
 
 function FOV = computeFOV(cfg)
+
 % computes the number of degrees of visual angle in the whole field of view
 FOV = 2 *( 180 * ( atan( cfg.monitorWidth / (2*cfg.screenDistance) ) / pi));
+
 end

--- a/initPTB.m
+++ b/initPTB.m
@@ -73,10 +73,8 @@ FOV = computeFOV(cfg);
 cfg.ppd = cfg.winRect(3)/FOV;
 
 
-%% Select specific text font, style and size:
-Screen('TextFont',cfg.win, cfg.textFont );
-Screen('TextSize',cfg.win, cfg.textSize);
-Screen('TextStyle', cfg.win, cfg.textStyle);
+%% Select specific text font, style and size
+initText(cfg)
 
 
 %% Timing
@@ -164,5 +162,14 @@ function FOV = computeFOV(cfg)
 
 % computes the number of degrees of visual angle in the whole field of view
 FOV = 2 *( 180 * ( atan( cfg.monitorWidth / (2*cfg.screenDistance) ) / pi));
+
+end
+
+
+function initText(cfg)
+
+Screen('TextFont', cfg.win, cfg.textFont);
+Screen('TextSize', cfg.win, cfg.textSize);
+Screen('TextStyle', cfg.win, cfg.textStyle);
 
 end

--- a/initPTB.m
+++ b/initPTB.m
@@ -26,7 +26,7 @@ more off
 % check for OpenGL compatibility, abort otherwise:
 AssertOpenGL;
 
-cfg = setDefaults(cfg);
+cfg = setDefaultsPTB(cfg);
 
 initDebug(cfg);
 
@@ -102,44 +102,6 @@ GetSecs;
 cfg.vbl = Screen('Flip', cfg.win);
 
 
-end
-
-function cfg = setDefaults(cfg)
-
-% list the default values
-fieldsToSet.keyboard = [];
-fieldsToSet.responseBox = [];
-
-fieldsToSet.debug = true;
-fieldsToSet.testingTranspScreen = true;
-fieldsToSet.testingSmallScreen = true;
-
-fieldsToSet.backgroundColor = [0 0 0];
-
-fieldsToSet.textFont = 'Courier New';
-fieldsToSet.textSize = 18;
-fieldsToSet.textStyle = 1;
-
-fieldsToSet.monitorWidth = 42;
-fieldsToSet.screenDistance = 134;
-
-% loop through the defaults and set them in cfg if they don't exist
-names = fieldnames(fieldsToSet);
-
-for i = 1:numel(names)
-    cfg = setFieldToIfNotPresent(...
-        cfg, ...
-        names{i}, ...
-        getfield(fieldsToSet, names{i})); %#ok<GFLD>
-end
-
-
-end
-
-function struct = setFieldToIfNotPresent(struct, fieldName, value)
-    if ~isfield(struct, fieldName)
-        struct = setfield(struct, fieldName, value); %#ok<SFLD>
-    end
 end
 
 

--- a/initPTB.m
+++ b/initPTB.m
@@ -1,14 +1,14 @@
 function [cfg] = initPTB(cfg)
 % This will initialize PsychToolBox
 % - screen
-%   - the windon opened takes the whole screen unless
-%       cfg.testingSmallScreen is set to true 
-%   - debug mode : skips synch test and warnings
-%   - window transparency enabled by cfg.testingTranspScreen set to true
-%   - gets the flip interval
-%   - computes the pixel per degree of visual angle:
-%       the computation for ppd assumes the windows takes the whole screenDistance
-%   - set font details
+% - the windon opened takes the whole screen unless
+% cfg.testingSmallScreen is set to true
+% - debug mode : skips synch test and warnings
+% - window transparency enabled by cfg.testingTranspScreen set to true
+% - gets the flip interval
+% - computes the pixel per degree of visual angle:
+% the computation for ppd assumes the windows takes the whole screenDistance
+% - set font details
 % - keyboard
 % - hides cursor
 % - sound
@@ -25,6 +25,8 @@ more off
 
 % check for OpenGL compatibility, abort otherwise:
 AssertOpenGL;
+
+cfg = setDefaults(cfg);
 
 initDebug(cfg);
 
@@ -104,21 +106,40 @@ end
 
 function cfg = setDefaults(cfg)
 
-cfg.keyboard = [];
-cfg.responseBox = [];
+% list the default values
+fieldsToSet.keyboard = [];
+fieldsToSet.responseBox = [];
 
-cfg.debug = true;
-cfg.testingTranspScreen = true;
-cfg.testingSmallScreen = true;
+fieldsToSet.debug = true;
+fieldsToSet.testingTranspScreen = true;
+fieldsToSet.testingSmallScreen = true;
 
-cfg.backgroundColor = [0 0 0];
+fieldsToSet.backgroundColor = [0 0 0];
 
-cfg.textFont = 'Courier New';
-cfg.textSize = 18;
-cfg.textStyle = 1;
+fieldsToSet.textFont = 'Courier New';
+fieldsToSet.textSize = 18;
+fieldsToSet.textStyle = 1;
 
-cfg.monitorWidth = 42;
-cfg.screenDistance = 134;
+fieldsToSet.monitorWidth = 42;
+fieldsToSet.screenDistance = 134;
+
+% loop through the defaults and set them in cfg if they don't exist
+names = fieldnames(fieldsToSet);
+
+for i = 1:numel(names)
+    cfg = setFieldToIfNotPresent(...
+        cfg, ...
+        names{i}, ...
+        getfield(fieldsToSet, names{i})); %#ok<GFLD>
+end
+
+
+end
+
+function struct = setFieldToIfNotPresent(struct, fieldName, value)
+    if ~isfield(struct, fieldName)
+        struct = setfield(struct, fieldName, value); %#ok<SFLD>
+    end
 end
 
 
@@ -164,7 +185,7 @@ end
 function cfg = openWindow(cfg)
 
 if cfg.testingSmallScreen
-    [cfg.win, cfg.winRect] = Screen('OpenWindow', cfg.screen, cfg.backgroundColor,  [0,0, 480, 270]);
+    [cfg.win, cfg.winRect] = Screen('OpenWindow', cfg.screen, cfg.backgroundColor, [0,0, 480, 270]);
 else
     [cfg.win, cfg.winRect] = Screen('OpenWindow', cfg.screen, cfg.backgroundColor);
 end

--- a/initPTB.m
+++ b/initPTB.m
@@ -102,6 +102,25 @@ cfg.vbl = Screen('Flip', cfg.win);
 
 end
 
+function cfg = setDefaults(cfg)
+
+cfg.keyboard = [];
+cfg.responseBox = [];
+
+cfg.debug = true;
+cfg.testingTranspScreen = true;
+cfg.testingSmallScreen = true;
+
+cfg.backgroundColor = [0 0 0];
+
+cfg.textFont = 'Courier New';
+cfg.textSize = 18;
+cfg.textStyle = 1;
+
+cfg.monitorWidth = 42;
+cfg.screenDistance = 134;
+end
+
 
 function initDebug(cfg)
 

--- a/initPTB.m
+++ b/initPTB.m
@@ -14,10 +14,9 @@ function [cfg] = initPTB(cfg)
 % TO DO
 % - We might want to add a couple of IF in case the experiment does not use audio for example.
 % - the computation for ppd assumes the windows takes the whole screenDistance
-% - refactor the window opening section (pass the window size as argument)
+
 
 checkDependencies()
-
 
 % For octave: to avoid displaying messenging one screen at a time
 more off
@@ -25,18 +24,18 @@ more off
 % check for OpenGL compatibility, abort otherwise:
 AssertOpenGL;
 
+initDebug(cfg);
+
 
 %% Keyboard
 initKeyboard(cfg)
 
 
 %% Mouse
-% Hide the mouse cursor:
 HideCursor;
 
 
 %% Audio
-% Intialize PsychPortAudio
 InitializePsychSound(1);
 
 
@@ -73,8 +72,6 @@ cfg.ppd = cfg.winRect(3)/FOV;
 
 
 %% Select specific text font, style and size:
-%% Text and Font
-% Select specific text font, style and size:
 Screen('TextFont',cfg.win, cfg.textFont );
 Screen('TextSize',cfg.win, cfg.textSize);
 Screen('TextStyle', cfg.win, cfg.textStyle);

--- a/initPTB.m
+++ b/initPTB.m
@@ -62,16 +62,14 @@ end
 
 
 
-
 % Get the Center of the Screen
 cfg.center = [cfg.winRect(3), cfg.winRect(4)]/2;
 
 % Computes the number of pixels per degree given the distance to screen and
 % monitor width
-
 % This assumes that the window fills the whole screen
-V = 2*(180*(atan(cfg.monitorWidth/(2*cfg.screenDistance))/pi));
-cfg.ppd = cfg.winRect(3)/V;
+FOV = computeFOV(cfg);
+cfg.ppd = cfg.winRect(3)/FOV;
 
 
 %% Select specific text font, style and size:
@@ -159,4 +157,9 @@ end
 % superposition with alpha-weighted source.
 Screen('BlendFunction', cfg.win, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
+end
+
+function FOV = computeFOV(cfg)
+% computes the number of degrees of visual angle in the whole field of view
+FOV = 2 *( 180 * ( atan( cfg.monitorWidth / (2*cfg.screenDistance) ) / pi));
 end

--- a/initPTB.m
+++ b/initPTB.m
@@ -53,17 +53,9 @@ cfg = openWindow(cfg);
 % window size info
 [cfg.winWidth, cfg.winHeight] = WindowSize(cfg.win);
 
-
-
-% ---------- FIX LATER ---------- %
-% I don't think we want to hard code the 2/3 here. We might just add it to
-% the Cfg structure
 if strcmpi(cfg.stimPosition,'scanner')
     cfg.winRect(1,4) = cfg.winRect(1,4)*2/3;
 end
-% ---------- FIX LATER ---------- %
-
-
 
 % Get the Center of the Screen
 cfg.center = [cfg.winRect(3), cfg.winRect(4)]/2;
@@ -135,17 +127,7 @@ function initKeyboard(cfg)
 % Apple MacOS/X, MS-Windows and GNU/Linux:
 KbName('UnifyKeyNames');
 
-
-
-% ---------- FIX LATER ---------- %
-% might be over agressive to test this at every PTB init maybe make it
-% dependent on a debug "flag"
-
 testKeyboards(cfg)
-
-% ---------- FIX LATER ---------- %
-
-
 
 % Don't echo keypresses to Matlab window
 ListenChar(-1);

--- a/initPTB.m
+++ b/initPTB.m
@@ -12,7 +12,31 @@ function [cfg] = initPTB(cfg)
 % - keyboard
 % - hides cursor
 % - sound
-
+%
+% OUTPUT:
+% cfg.keyboard = [];
+% cfg.responseBox = [];
+% 
+% cfg.debug = true;
+% cfg.testingTranspScreen = true;
+% cfg.testingSmallScreen = true;
+% 
+% cfg.screen : screen numbers where drawing the stimulation (external screen if available)
+% cfg.win : window opened by PTB
+% cfg.winRect : window rectangule positiona and dimensions in pixel coordinates
+% cfg.winWidth : window width in pixels
+% cfg.winHeight : window height in pixels
+% cfg.center : coordinate of the window center
+% cfg.ppd : pixels per degree assuming the window fills the whole screen
+% cfg.ifi : estimate of the monitor flip interval
+% cfg.monRefresh : monitor refresh rate
+% cfg.vbl : (I don't think this output is useful)
+% cfg.textFont = 'Courier New';
+% cfg.textSize = 18;
+% cfg.textStyle = 1;
+% cfg.backgroundColor = [0 0 0];
+% cfg.monitorWidth = 42;
+% cfg.screenDistance = 134;
 
 % TO DO
 % - We might want to add a couple of IF in case the experiment does not use audio for example.

--- a/initPTB.m
+++ b/initPTB.m
@@ -200,10 +200,10 @@ function cfg = initAudio(cfg)
         % at the begining of the experiment)
         PsychPortAudio('Volume', cfg.audio.pahandle, cfg.audio.initVolume);
         
-        cfg.audio.pushSize  = cfg.fs*0.010; %! push N ms only
+        cfg.audio.pushSize  = cfg.audio.fs * 0.010; %! push N ms only
         
         cfg.audio.requestOffsetTime = 1; % offset 1 sec
-        cfg.audio.reqsSampleOffset = cfg.audio.requestOffsetTime*cfg.audio.fs;
+        cfg.audio.reqsSampleOffset = cfg.audio.requestOffsetTime * cfg.audio.fs;
 
     end
 end

--- a/initPTB.m
+++ b/initPTB.m
@@ -110,9 +110,17 @@ function initDebug(cfg)
 % init PTB with different options in concordance to the debug Parameters
 Screen('Preference','SkipSyncTests', 0);
 if cfg.debug
+    
     Screen('Preference', 'SkipSyncTests', 2);
     Screen('Preference', 'Verbosity', 0);
     Screen('Preferences', 'SuppressAllWarnings', 2);
+    
+    fprintf('\n\n\n\n')
+    fprintf('########################################\n')
+    fprintf('##   DEBUG MODE. TIMING WILL BE OFF.  ##\n')
+    fprintf('########################################')
+    fprintf('\n\n\n\n')
+    
 end
 
 if cfg.testingTranspScreen

--- a/initPTB.m
+++ b/initPTB.m
@@ -162,9 +162,7 @@ end
 function cfg = initAudio(cfg)
     
     if cfg.initAudio
-        
-        requestedLatency = 3;
-        
+
         InitializePsychSound(1);
 
         cfg.audio.devIdx= [];
@@ -192,7 +190,7 @@ function cfg = initAudio(cfg)
         cfg.audio.pahandle = PsychPortAudio('Open', ...
             cfg.audio.devIdx, ...
             cfg.audio.playbackMode, ...
-            requestedLatency, ...
+            cfg.audio.requestedLatency, ...
             cfg.audio.fs, ...
             cfg.audio.channels);
         

--- a/initPTB.m
+++ b/initPTB.m
@@ -56,7 +56,7 @@ initDebug(cfg);
 
 
 %% Keyboard
-initKeyboard(cfg)
+initKeyboard
 
 
 %% Mouse
@@ -192,6 +192,8 @@ if cfg.debug
     fprintf('########################################')
     fprintf('\n\n\n\n')
     
+    testKeyboards(cfg)
+    
 end
 
 if cfg.testingTranspScreen
@@ -200,13 +202,11 @@ end
 
 end
 
-function initKeyboard(cfg)
+function initKeyboard
 
 % Make sure keyboard mapping is the same on all supported operating systems
 % Apple MacOS/X, MS-Windows and GNU/Linux:
 KbName('UnifyKeyNames');
-
-testKeyboards(cfg)
 
 % Don't echo keypresses to Matlab window
 ListenChar(-1);

--- a/initPTB.m
+++ b/initPTB.m
@@ -170,16 +170,16 @@ function cfg = initAudio(cfg)
         cfg.audio.devIdx= [];
         cfg.audio.playbackMode = 1;
             
-        if IsWin
+        if isfield(cfg.audio, 'useDevice')
             
             % get audio device list
             audioDev = PsychPortAudio('GetDevices');
             
-            % find output device using WASAPI driver
+            % find output device to use
             idx = find(...
-                audioDev.NrInputChannels == 0 && ...
-                audioDev.NrOutputChannels == 2 && ...
-                ~cellfun(@isempty, regexp({audioDev.HostAudioAPIName}, 'WASAPI')));
+                audioDev.NrInputChannels == cfg.audio.inputChannels && ...
+                audioDev.NrOutputChannels == cfg.audio.channels && ...
+                ~cellfun(@isempty, regexp({audioDev.HostAudioAPIName}, cfg.audio.deviceName)));
             
             % save device ID
             cfg.audio.devIdx = audioDev(idx).DeviceIndex;
@@ -215,8 +215,6 @@ if cfg.testingSmallScreen
 else
     [cfg.win, cfg.winRect] = Screen('OpenWindow', cfg.screen, cfg.backgroundColor);
 end
-
-%TODO make this optional
 
 % Enable alpha-blending, set it to a blend equation useable for linear
 % superposition with alpha-weighted source.

--- a/setDefaultsPTB.m
+++ b/setDefaultsPTB.m
@@ -1,0 +1,37 @@
+function cfg = setDefaultsPTB(cfg)
+
+% list the default values
+fieldsToSet.keyboard = [];
+fieldsToSet.responseBox = [];
+
+fieldsToSet.debug = true;
+fieldsToSet.testingTranspScreen = true;
+fieldsToSet.testingSmallScreen = true;
+
+fieldsToSet.backgroundColor = [0 0 0];
+
+fieldsToSet.textFont = 'Courier New';
+fieldsToSet.textSize = 18;
+fieldsToSet.textStyle = 1;
+
+fieldsToSet.monitorWidth = 42;
+fieldsToSet.screenDistance = 134;
+
+% loop through the defaults and set them in cfg if they don't exist
+names = fieldnames(fieldsToSet);
+
+for i = 1:numel(names)
+    cfg = setFieldToIfNotPresent(...
+        cfg, ...
+        names{i}, ...
+        getfield(fieldsToSet, names{i})); %#ok<GFLD>
+end
+
+
+end
+
+function struct = setFieldToIfNotPresent(struct, fieldName, value)
+    if ~isfield(struct, fieldName)
+        struct = setfield(struct, fieldName, value); %#ok<SFLD>
+    end
+end

--- a/setDefaultsPTB.m
+++ b/setDefaultsPTB.m
@@ -22,6 +22,7 @@ if isfield(cfg, 'initAudio') && cfg.initAudio
     fieldsToSet.audio.fs = 44800;
     fieldsToSet.audio.channels = 2;
     fieldsToSet.audio.initVolume = 1;
+    fieldsToSet.audio.requestedLatency = 3;
     
     % playing parameters
     % sound repetition

--- a/setDefaultsPTB.m
+++ b/setDefaultsPTB.m
@@ -17,6 +17,24 @@ fieldsToSet.textStyle = 1;
 fieldsToSet.monitorWidth = 42;
 fieldsToSet.screenDistance = 134;
 
+if isfield(cfg, 'initAudio') && cfg.initAudio
+    
+    fieldsToSet.audio.fs = 44800;
+    fieldsToSet.audio.channels = 2;
+    fieldsToSet.audio.initVolume = 1;
+    
+    % playing parameters
+    % sound repetition
+    fieldsToSet.audio.repeat = 1;
+    
+    % Start immediately (0 = immediately)
+    fieldsToSet.audio.startCue = 0;
+    
+    % Should we wait for the device to really start?
+    fieldsToSet.audio.waitForDevice = 1;
+
+end
+
 % loop through the defaults and set them in cfg if they don't exist
 names = fieldnames(fieldsToSet);
 

--- a/testKeyboards.m
+++ b/testKeyboards.m
@@ -5,7 +5,6 @@ function testKeyboards(cfg)
 timeOut = 5;
 
 
-
 % Main keyboard used by the experimenter to quit the experiment if it is necessary
 % cfg.keyboard
 fprintf('\n This is a test: press any key on the experimenter keyboard\n');


### PR DESCRIPTION
This is a big refactoring of the initPTB function into many subfunctions.

Also allowing to set some defaults if they are not passed by the user. 

- create sub-functions for
  - initialization of keyboard, 
  - debug
    - small screen, transparency and debug can all be set independently
  - opening window, 
  - computing field of view
  - initialize fonts
  - implement a function to set defaults for initPTB so that users don't have to specify them if they want to be lazy