### PR TITLE
waitForTrigerr, from KbPressWait to KbCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Tested:
 
 ## Documentation
 
-All the documentation is accessible [here](./docs/00_index.md).
+All the documentation is accessible [here](./docs/00-index.md).
 
 ## Content
 

--- a/demos/CPP_waitForTriggerDemo.m
+++ b/demos/CPP_waitForTriggerDemo.m
@@ -1,9 +1,8 @@
+% add parent/src directory to the path (to make sure we can access the CPP_PTB functions)
+
 addpath(genpath(fullfile(pwd, '..', 'src')));
 
-%%
-cfg.testingDevice = 'mri';
-
-cfg.mri.triggerNb = 2;
+cfg.mri.triggerNb = 5;
 
 cfg.mri.triggerKey = 't';
 
@@ -17,5 +16,4 @@ quietMode = false;
 % waitForTrigger(cfg, [], quietMode);
 
 %%
-nbTriggersToWait = 5;
-waitForTrigger(cfg, [], quietMode, nbTriggersToWait);
+waitForTrigger(cfg, [], quietMode, cfg.mri.triggerNb);

--- a/demos/CPP_waitForTriggerDemo.m
+++ b/demos/CPP_waitForTriggerDemo.m
@@ -5,7 +5,7 @@ cfg.testingDevice = 'mri';
 
 cfg.mri.triggerNb = 2;
 
-cfg.mri.triggerKey = 'space';
+cfg.mri.triggerKey = 't';
 
 KbName('UnifyKeyNames');
 
@@ -13,9 +13,9 @@ KbName('UnifyKeyNames');
 % waitForTrigger(cfg);
 
 %%
-quietMode = true;
+quietMode = false;
 % waitForTrigger(cfg, [], quietMode);
 
 %%
-nbTriggersToWait = 1;
+nbTriggersToWait = 5;
 waitForTrigger(cfg, [], quietMode, nbTriggersToWait);

--- a/src/waitForTrigger.m
+++ b/src/waitForTrigger.m
@@ -26,7 +26,7 @@ function waitForTrigger(varargin)
     % - varargin{3} = quietMode: a boolean to make sure nothing is printed on the screen or
     % the prompt
     %
-    % - nvarargin{3} = bTriggersToWait
+    % - nvarargin{3} = nbTriggersToWait
 
     [cfg, nbTriggersToWait, deviceNumber, quietMode] = checkInputs(varargin);
 

--- a/src/waitForTrigger.m
+++ b/src/waitForTrigger.m
@@ -19,14 +19,14 @@ function waitForTrigger(varargin)
     % triggers coming from the scanner in a real case scenario.
     %
     % INPUTS
-    %  - varargin{1} = cfg
+    % - varargin{1} = cfg
     %
     % - varargin{2} = deviceNumber
     %
     % - varargin{3} = quietMode: a boolean to make sure nothing is printed on the screen or
     % the prompt
     %
-    % - nbTriggersToWait
+    % - nvarargin{3} = bTriggersToWait
 
     [cfg, nbTriggersToWait, deviceNumber, quietMode] = checkInputs(varargin);
 
@@ -43,7 +43,13 @@ function waitForTrigger(varargin)
 
             keyCode = []; %#ok<NASGU>
 
-            [~, keyCode] = KbPressWait(deviceNumber);
+            % Check that all buuton are released
+            % isDown = KbCheck;
+            % while isDown
+            %   isDown = KbCheck;
+            % end
+
+            [~, ~, keyCode] = KbCheck(deviceNumber);
 
             if strcmp(KbName(keyCode), cfg.mri.triggerKey)
 

--- a/src/waitForTrigger.m
+++ b/src/waitForTrigger.m
@@ -43,12 +43,6 @@ function waitForTrigger(varargin)
 
             keyCode = []; %#ok<NASGU>
 
-            % Check that all buuton are released
-            % isDown = KbCheck;
-            % while isDown
-            %   isDown = KbCheck;
-            % end
-
             [~, ~, keyCode] = KbCheck(deviceNumber);
 
             if strcmp(KbName(keyCode), cfg.mri.triggerKey)

--- a/src/waitForTrigger.m
+++ b/src/waitForTrigger.m
@@ -26,7 +26,7 @@ function waitForTrigger(varargin)
     % - varargin{3} = quietMode: a boolean to make sure nothing is printed on the screen or
     % the prompt
     %
-    % - nvarargin{3} = nbTriggersToWait
+    % - nvarargin{4} = nbTriggersToWait
 
     [cfg, nbTriggersToWait, deviceNumber, quietMode] = checkInputs(varargin);
 


### PR DESCRIPTION
Changed KbPressWait to KbCheck so that triggerino can be used with this. 

I did not add any check for all key released (the classic `while KbCheck; end`) because it is useless since the func has a `pauseBetweenTriggers` (either 0.5 secs or `cfg.mri.repetitionTime / 2`). With the check it has a weird behavior, I don't know why.

The 'downside' of that is that  if you keep the `triggerKey' pressed it will take the triggers at the pace of `pauseBetweenTriggers`, but I think we can live with that.

fix #115
