### PR TITLE
add a default for letting the MRI scanner pace the experiment with triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- lint disable -->
+
 **Cite it**
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4007672.svg)](https://doi.org/10.5281/zenodo.4007672)
@@ -20,8 +22,6 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # CPP_PTB
-
-<!-- lint disable -->
 
 <!-- TOC -->
 

--- a/src/utils/setDefaultsPTB.m
+++ b/src/utils/setDefaultsPTB.m
@@ -83,6 +83,7 @@ function cfg = setDefaultsPTB(cfg)
 
     if isfield(cfg, 'testingDevice') && strcmpi(cfg.testingDevice, 'mri')
         fieldsToSet.bids.mri.RepetitionTime = [];
+        fieldsToSet.pacedByTriggers.do = false;
     end
 
     cfg = setDefaults(cfg, fieldsToSet);

--- a/tests/test_setDefaultsPTB.m
+++ b/tests/test_setDefaultsPTB.m
@@ -59,6 +59,23 @@ function test_setDefaultsPtbAudio()
 
 end
 
+function test_setDefaultsPtbMRI()
+
+    % set up
+    cfg.testingDevice = 'mri';
+    cfg = setDefaultsPTB(cfg);
+
+    % test data
+    expectedCfg = returnExpectedCFG();
+    expectedCfg.testingDevice = 'mri';
+    expectedCfg.bids.mri.RepetitionTime = [];
+    expectedCfg.pacedByTriggers.do = false;
+
+    % test
+    assertEqual(expectedCfg, cfg);
+
+end
+
 function expectedCFG = returnExpectedCFG()
 
     expectedCFG =  struct( ...


### PR DESCRIPTION
the default is `false`